### PR TITLE
feat: Add possibility for including rule for multiple partial replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,40 @@ You can use RegExp for package name:
 }
 ```
 
+Is it possible as well to perform multiple partial replacements by setting and Object in the `replacement` property:
+
+```json
+{
+  "rules": {
+    "restrict-replace-import/restrict-import": [
+      "error",
+      [
+        {
+          "target": "with-partial-.*",
+          "replacement": {
+            "par(regExp)?tial-": "successfully-",
+            "repla(regExp)?cements": "replaced",
+            "with-": "",
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+Given that rule configuration it will perform the following replacement:
+
+Input:
+```js
+import { useState } from 'with-partial-replacements'
+```
+
+Output:
+```js
+import { useState } from 'successfully-replaced'
+```
+
+
 ## Rules
 
 <!-- begin auto-generated rules list -->

--- a/lib/rules/restrict-import.js
+++ b/lib/rules/restrict-import.js
@@ -41,7 +41,15 @@ module.exports = {
                   type: "string",
                 },
                 replacement: {
-                  type: "string",
+                  oneOf: [
+                    { type: "string" },
+                    { 
+                      type: "object", 
+                      patternProperties: {
+                        ".*": { type: "string" }
+                      }
+                    }
+                  ]
                 },
               },
               required: ["target"],
@@ -119,7 +127,7 @@ module.exports = {
 
         context.report({
           node,
-          messageId: replacement
+          messageId: typeof replacement === "string"
             ? "ImportRestrictionWithReplacement"
             : "ImportRestriction",
           data: {
@@ -131,10 +139,26 @@ module.exports = {
               return;
             }
 
-            return fixer.replaceText(
-              node.source,
-              `${quote}${replacement}${quote}`
-            );
+            if (typeof replacement === "string") {
+              return fixer.replaceText(
+                node.source,
+                `${quote}${replacement}${quote}`
+              );
+            }
+
+            if (typeof replacement === "object") {
+              let partiallyReplaced = node.source.value;
+              for (const [key, value] of Object.entries(replacement)) {
+                const regex = new RegExp(key, 'g');
+                partiallyReplaced = partiallyReplaced.replace(regex, value);
+              }
+              return fixer.replaceText(
+                node.source,
+                `${quote}${partiallyReplaced}${quote}`
+              );
+            }
+
+            return null;
           },
         });
       },

--- a/tests/lib/rules/restrict-import.js
+++ b/tests/lib/rules/restrict-import.js
@@ -38,6 +38,14 @@ const OPTIONS = [
       target: "with(?:-regex)?-support",
       replacement: "with-support-replacement",
     },
+    {
+      target: "with-partial-replacements",
+      replacement: {
+        "par(regExp)?tial-": "successfully-",
+        "repla(regExp)?cements": "replaced",
+        "with-": "",
+      }
+    },
   ],
 ];
 
@@ -144,6 +152,18 @@ ruleTester.run("restrict-import", rule, {
       ],
       options: OPTIONS,
       output: 'import { ReactNode } from "preact";',
+    },
+    {
+      code: "import { useState } from 'with-partial-replacements'",
+      errors: [
+        {
+          message: "`with-partial-replacements` is restricted from being used.",
+          type: "ImportDeclaration",
+        },
+      ],
+      options: OPTIONS,
+      output:
+        "import { useState } from 'successfully-replaced'",
     },
   ],
 });


### PR DESCRIPTION
**Why?**
Add possibility for adding multiple partial replacements as rule.

So, in addition to the current configuration options this PR is adding possibility to define a rule that performs multiple replacements over the input, defining the rule like:

```json
{
  "rules": {
    "restrict-replace-import/restrict-import": [
      "error",
      [
        {
          "target": "with-partial-.*",
          "replacement": {
            "par(regExp)?tial-": "successfully-",
            "repla(regExp)?cements": "replaced",
            "with-": "",
          }
        }
      ]
    ]
  }
}
```
Given that rule configuration it will perform the following replacement:

Input:
```js
import { useState } from 'with-partial-replacements'
```

Output:
```js
import { useState } from 'successfully-replaced'
```